### PR TITLE
Fix semantics of extort (errors)

### DIFF
--- a/www/notes/extort/semantics.rkt
+++ b/www/notes/extort/semantics.rkt
@@ -10,14 +10,17 @@
 (define-extended-judgment-form E 𝑫
   #:mode (𝑬 I O)
   #:contract (𝑬 e a)
-  [--------
-   (𝑬 (add1 b) err)]
+  [(𝑬 e b)
+   --------
+   (𝑬 (add1 e) err)]
 
-  [-----------
-   (𝑬 (sub1 b) err)]
+  [(𝑬 e b)
+   -----------
+   (𝑬 (sub1 e) err)]
 
-  [-----------
-   (𝑬 (zero? b) err)]
+  [(𝑬 e b)
+   -----------
+   (𝑬 (zero? e) err)]
 
   [(𝑬 e err)
    -----------


### PR DESCRIPTION
The semantics for extort were wrong (they used small-step-style rules for introducing errors even though the semantics is big-step).  This adds test cases that demonstrate the problem and fixes the semantics.  It doesn't look like the writing in the notes needs to be updated.

I didn't push this to the master branch just in case doing so would cause problems for the current course.