### PR TITLE
Allow any entry point in asm-interp

### DIFF
--- a/langs/a86/ast.rkt
+++ b/langs/a86/ast.rkt
@@ -170,9 +170,9 @@
 ;; prevent confusing error messages as the nasm level
 (define (prog . xs)
   (let ((p (apply seq xs)))
-    (check-unique-label-decls xs)
-    (check-label-targets-declared xs)
-    (check-has-initial-label xs)
+    (check-unique-label-decls p)
+    (check-label-targets-declared p)
+    (check-has-initial-label p)
     ;; anything else?
     p))
 

--- a/langs/a86/ast.rkt
+++ b/langs/a86/ast.rkt
@@ -172,6 +172,7 @@
   (let ((p (apply seq xs)))
     (check-unique-label-decls xs)
     (check-label-targets-declared xs)
+    (check-has-initial-label xs)
     ;; anything else?
     p))
 
@@ -228,3 +229,8 @@
     (let ((undeclared (set-subtract us ds)))
       (unless (set-empty? undeclared)
         (error 'prog "undeclared labels found: ~v" (set->list undeclared))))))
+
+;; Asm -> Void
+(define (check-has-initial-label asm)
+  (unless (findf Label? asm)
+    (error 'prog "no initial label found")))

--- a/langs/a86/interp.rkt
+++ b/langs/a86/interp.rkt
@@ -51,7 +51,14 @@
            t.so))
 
   (define libt.so (ffi-lib t.so))
-  (define entry (get-ffi-obj "entry" libt.so (_fun _-> _int64)))
+
+  (define init-label
+    (match (findf Label? a)
+      [(Label l) l]
+      [_ (error "no initial label found")]))
+
+  (define entry
+    (get-ffi-obj init-label libt.so (_fun _-> _int64)))
 
   ;; install our own `error_handler` procedure to prevent `exit` calls
   ;; from interpreted code bringing down the parent process.  All of

--- a/langs/a86/printer.rkt
+++ b/langs/a86/printer.rkt
@@ -131,4 +131,6 @@
       "\tglobal " (label-symbol->string g) "\n"
       "\tdefault rel\n"
       "\tsection .text\n"
-      (foldl (λ (i s) (string-append s (instr->string i))) "" a))]))
+      (foldl (λ (i s) (string-append s (instr->string i))) "" a))]
+    [_
+     (error "program does not have an initial label")]))

--- a/www/notes/a86.scrbl
+++ b/www/notes/a86.scrbl
@@ -690,6 +690,7 @@ assembly code when running @racket[asm-interp].
 
  @itemlist[
 
+ @item{Programs have at least one label; the first label is used as the entry point.}
  @item{All label declarations are unique.}
  @item{All label targets are declared.}
  @item{... other properties may be added in the future.}
@@ -702,10 +703,10 @@ assembly code when running @racket[asm-interp].
  outermost level of a function that produces a86 code and not
  nested.
 
- @ex[
- (prog)
+ @ex[ 
  (prog (Label 'foo))
  (prog (list (Label 'foo)))
+ (eval:error (prog (Mov 'rax 32)))
  (eval:error (prog (Label 'foo)
                    (Label 'foo)))
  (eval:error (prog (Jmp 'foo)))


### PR DESCRIPTION
Remove the assumption that the asm program starts with `'entry` and allow any label; first label is used as the entry point.  Have `prog` check that there's at least one label.