### PR TITLE
Fix interp-env* 

### DIFF
--- a/langs/iniquity-gc/interp.rkt
+++ b/langs/iniquity-gc/interp.rkt
@@ -88,12 +88,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> Defn
 (define (defns-lookup ds f)

--- a/langs/iniquity-plus/interp.rkt
+++ b/langs/iniquity-plus/interp.rkt
@@ -130,12 +130,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> Defn
 (define (defns-lookup ds f)

--- a/langs/iniquity/interp.rkt
+++ b/langs/iniquity/interp.rkt
@@ -86,12 +86,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> Defn
 (define (defns-lookup ds f)

--- a/langs/jig/interp.rkt
+++ b/langs/jig/interp.rkt
@@ -86,12 +86,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> Defn
 (define (defns-lookup ds f)

--- a/langs/knock/interp.rkt
+++ b/langs/knock/interp.rkt
@@ -123,12 +123,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> Defn
 (define (defns-lookup ds f)

--- a/langs/loot/interp.rkt
+++ b/langs/loot/interp.rkt
@@ -138,12 +138,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> [Maybe Defn]
 (define (defns-lookup ds f)

--- a/langs/mountebank/interp.rkt
+++ b/langs/mountebank/interp.rkt
@@ -133,12 +133,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> [Maybe Defn]
 (define (defns-lookup ds f)

--- a/langs/mug/interp.rkt
+++ b/langs/mug/interp.rkt
@@ -141,12 +141,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> [Maybe Defn]
 (define (defns-lookup ds f)

--- a/langs/neerdowell/interp.rkt
+++ b/langs/neerdowell/interp.rkt
@@ -120,12 +120,15 @@
 
 ;; (Listof Expr) REnv Defns -> (Listof Value) | 'err
 (define (interp-env* es r ds)
-  (match es
-    ['() '()]
-    [(cons e es)
-     (match (interp-env e r ds)
-       ['err 'err]
-       [v (cons v (interp-env* es r ds))])]))
+  (foldr
+    (lambda (e acc)
+      (if (eq? acc 'err)
+          'err
+          (match (interp-env e r ds)
+            ['err 'err]
+            [v (cons (interp-env e r ds) acc)])))
+    '()
+    es))
 
 ;; Defns Symbol -> [Maybe Defn]
 (define (defns-lookup ds f)


### PR DESCRIPTION
In the old version when the error occurs not in the first expression in 'es', the result is an improper list that looks like '( 1 2 3 . err) (if the error is in the fourth expression). But we want to return 'err.