### PR TITLE
Fix minor typo in Assignment 4

### DIFF
--- a/www/assignments/4.scrbl
+++ b/www/assignments/4.scrbl
@@ -183,7 +183,7 @@ write additional test cases.
 @section[#:tag-prefix "a4-" #:style 'unnumbered]{Submitting}
 
 Submit a zip file containing your work to Gradescope.  Use @tt{make
-submit.zip} from within the @tt{dupe-plus} directory to create a zip
+submit.zip} from within the @tt{fraud-plus} directory to create a zip
 file with the proper structure.
 
 We will only use the @tt{compile.rkt}, @tt{interp.rkt}, and


### PR DESCRIPTION
The command needs to be run in the `fraud-plus` directory not the `dupe-plus` directory.