### PR TITLE
r15, void, CEnv

### DIFF
--- a/langs/extort/compile-ops.rkt
+++ b/langs/extort/compile-ops.rkt
@@ -41,8 +41,7 @@
     ['write-byte
      (seq (assert-byte)
           (Mov rdi rax)
-          (Call 'write_byte)
-          (Mov rax (value->bits (void))))]))
+          (Call 'write_byte))]))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/langs/fraud/compile-ops.rkt
+++ b/langs/fraud/compile-ops.rkt
@@ -50,8 +50,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax (value->bits (void))))]))
+          unpad-stack)]))
 
 ;; Op2 -> Asm
 (define (compile-op2 p)

--- a/langs/fraud/compile.rkt
+++ b/langs/fraud/compile.rkt
@@ -8,7 +8,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = (Listof ID)
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Expr -> Asm
 (define (compile e)

--- a/langs/fraud/compile.rkt
+++ b/langs/fraud/compile.rkt
@@ -6,6 +6,7 @@
 (define rax 'rax) ; return
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = (Listof ID)
 
@@ -17,7 +18,9 @@
         (Extern 'raise_error)
         (Global 'entry)
         (Label 'entry)
+        (Push r15)    ; save callee-saved register
         (compile-e e '())
+        (Pop r15)     ; restore callee-save register
         (Ret)
         (Label 'raise_error_align)
         pad-stack

--- a/langs/hoax/compile-ops.rkt
+++ b/langs/hoax/compile-ops.rkt
@@ -52,8 +52,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax (value->bits (void))))]
+          unpad-stack)]
     ['box
      (seq (Mov (Offset rbx 0) rax)
           (Mov rax rbx)
@@ -144,11 +143,11 @@
      (seq (Pop r8)
           (Cmp rax r8)
 	  (if-equal))]
-    ['make-vector
+    ['make-vector ;; size value
      (let ((loop (gensym))
            (done (gensym))
            (empty (gensym)))
-       (seq (Pop r8)
+       (seq (Pop r8) ;; r8 = size
             (assert-natural r8)
             (Cmp r8 0) ; special case empty vector
             (Je empty)
@@ -174,7 +173,7 @@
             (Mov rax type-vect)
             (Label done)))]
 
-    ['vector-ref
+    ['vector-ref ; vector index
      (seq (Pop r8)
           (assert-vector r8)
           (assert-integer rax)

--- a/langs/hoax/compile.rkt
+++ b/langs/hoax/compile.rkt
@@ -9,7 +9,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Variable]
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Expr -> Asm
 (define (compile e)

--- a/langs/hoax/compile.rkt
+++ b/langs/hoax/compile.rkt
@@ -7,6 +7,7 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Variable]
 
@@ -19,9 +20,11 @@
         (Global 'entry)
         (Label 'entry)
 	(Push rbx)    ; save callee-saved register
+        (Push r15)        
         (Mov rbx rdi) ; recv heap pointer
         (compile-e e '())
-	(Pop rbx)     ; restore callee-save register
+        (Pop r15)     ; restore callee-save register
+        (Pop rbx)
 	(Ret)
         (Label 'raise_error_align)
         pad-stack

--- a/langs/hustle/compile-ops.rkt
+++ b/langs/hustle/compile-ops.rkt
@@ -49,13 +49,12 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax val-void))]
+          unpad-stack)]
     ['box
-     (seq (Mov (Offset rbx 0) rax)
-          (Mov rax rbx)
-          (Or rax type-box)
-          (Add rbx 8))]
+     (seq (Mov (Offset rbx 0) rax) ; memory write
+          (Mov rax rbx)            ; put box in rax
+          (Or rax type-box)        ; tag as a box
+          (Add rbx 8))]            ; move rbx 8 bytes over
     ['unbox
      (seq (assert-box rax)
           (Xor rax type-box)

--- a/langs/hustle/compile.rkt
+++ b/langs/hustle/compile.rkt
@@ -7,6 +7,7 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Variable]
 
@@ -19,9 +20,11 @@
         (Global 'entry)
         (Label 'entry)
 	(Push rbx)    ; save callee-saved register
+        (Push r15)
         (Mov rbx rdi) ; recv heap pointer
-        (compile-e e '())
-	(Pop rbx)     ; restore callee-save register
+        (compile-e e '())        
+	(Pop r15)     ; restore callee-save register
+        (Pop rbx)
         (Ret)
         (Label 'raise_error_align)
         pad-stack

--- a/langs/hustle/compile.rkt
+++ b/langs/hustle/compile.rkt
@@ -9,7 +9,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Variable]
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Expr -> Asm
 (define (compile e)

--- a/langs/iniquity/compile-ops.rkt
+++ b/langs/iniquity/compile-ops.rkt
@@ -52,8 +52,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax (value->bits (void))))]
+          unpad-stack)]
     ['box
      (seq (Mov (Offset rbx 0) rax)
           (Mov rax rbx)

--- a/langs/iniquity/compile.rkt
+++ b/langs/iniquity/compile.rkt
@@ -9,7 +9,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Variable]
+;; type CEnv = (Listof [Maybe Id])
   
 ;; Prog -> Asm
 (define (compile p)

--- a/langs/iniquity/compile.rkt
+++ b/langs/iniquity/compile.rkt
@@ -7,20 +7,23 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Variable]
   
 ;; Prog -> Asm
 (define (compile p)
   (match p
-    [(Prog ds e)  
+    [(Prog ds e)
      (prog (externs)
            (Global 'entry)
            (Label 'entry)
-           (Push rbx)    ; save callee-saved register	   
+           (Push rbx)    ; save callee-saved register
+           (Push r15)
            (Mov rbx rdi) ; recv heap pointer
            (compile-e e '())
-           (Pop rbx)     ; restore callee-save register
+           (Pop r15)     ; restore callee-save register
+           (Pop rbx)
            (Ret)
            (compile-defines ds)
            (Label 'raise_error_align)

--- a/langs/jig/compile-ops.rkt
+++ b/langs/jig/compile-ops.rkt
@@ -52,8 +52,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax (value->bits (void))))]
+          unpad-stack)]
     ['box
      (seq (Mov (Offset rbx 0) rax)
           (Mov rax rbx)

--- a/langs/jig/compile.rkt
+++ b/langs/jig/compile.rkt
@@ -9,7 +9,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Variable]
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Prog -> Asm
 (define (compile p)

--- a/langs/jig/compile.rkt
+++ b/langs/jig/compile.rkt
@@ -7,6 +7,7 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Variable]
 
@@ -17,10 +18,12 @@
      (prog (externs)
            (Global 'entry)
            (Label 'entry)
-           (Push rbx)    ; save callee-saved register	   
+           (Push rbx)    ; save callee-saved register
+           (Push r15)
            (Mov rbx rdi) ; recv heap pointer
            (compile-e e '() #f)
-           (Pop rbx)     ; restore callee-save register
+           (Pop r15)     ; restore callee-save register
+           (Pop rbx)
            (Ret)
            (compile-defines ds)
            (Label 'raise_error_align)

--- a/langs/knock/compile-ops.rkt
+++ b/langs/knock/compile-ops.rkt
@@ -52,8 +52,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax (value->bits (void))))]
+          unpad-stack)]
     ['box
      (seq (Mov (Offset rbx 0) rax)
           (Mov rax rbx)

--- a/langs/knock/compile.rkt
+++ b/langs/knock/compile.rkt
@@ -9,7 +9,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Variable]
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Prog -> Asm
 (define (compile p)

--- a/langs/knock/compile.rkt
+++ b/langs/knock/compile.rkt
@@ -7,6 +7,7 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Variable]
 
@@ -17,10 +18,12 @@
      (prog (externs)
            (Global 'entry)
            (Label 'entry)
-           (Push rbx)    ; save callee-saved register	   
+           (Push rbx)    ; save callee-saved register
+           (Push r15)        
            (Mov rbx rdi) ; recv heap pointer
            (compile-e e '() #f)
-           (Pop rbx)     ; restore callee-save register
+           (Pop r15)     ; restore callee-save register
+           (Pop rbx)
            (Ret)
            (compile-defines ds)
            (Label 'raise_error_align)

--- a/langs/loot/compile-ops.rkt
+++ b/langs/loot/compile-ops.rkt
@@ -52,8 +52,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax (value->bits (void))))]
+          unpad-stack)]
     ['box
      (seq (Mov (Offset rbx 0) rax)
           (Mov rax rbx)

--- a/langs/loot/compile.rkt
+++ b/langs/loot/compile.rkt
@@ -9,7 +9,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Id]
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Prog -> Asm
 (define (compile p)

--- a/langs/loot/compile.rkt
+++ b/langs/loot/compile.rkt
@@ -7,6 +7,7 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Id]
 
@@ -17,12 +18,14 @@
      (prog (externs)
            (Global 'entry)
            (Label 'entry)
-           (Push rbx)    ; save callee-saved register	   
+           (Push rbx)    ; save callee-saved register
+           (Push r15)        
            (Mov rbx rdi) ; recv heap pointer
            (compile-defines-values ds)
            (compile-e e (reverse (define-ids ds)) #f)
            (Add rsp (* 8 (length ds))) ;; pop function definitions
-           (Pop rbx)     ; restore callee-save register
+           (Pop r15)     ; restore callee-save register
+           (Pop rbx)
            (Ret)
            (compile-defines ds)
            (compile-lambda-defines (lambdas p))

--- a/langs/mountebank/compile-ops.rkt
+++ b/langs/mountebank/compile-ops.rkt
@@ -55,8 +55,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax val-void))]
+          unpad-stack)]
     ['box
      (seq (Mov (Offset rbx 0) rax)
           (Mov rax rbx)

--- a/langs/mountebank/compile.rkt
+++ b/langs/mountebank/compile.rkt
@@ -14,6 +14,7 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Id]
 
@@ -24,13 +25,15 @@
      (prog (externs)
            (Global 'entry)
            (Label 'entry)
-           (Push rbx)    ; save callee-saved register	   
+           (Push rbx)    ; save callee-saved register
+           (Push r15)
            (Mov rbx rdi) ; recv heap pointer
            (init-symbol-table p)
            (compile-defines-values ds)
            (compile-e e (reverse (define-ids ds)) #f)
            (Add rsp (* 8 (length ds))) ;; pop function definitions
-           (Pop rbx)     ; restore callee-save register
+           (Pop r15)     ; restore callee-save register
+           (Pop rbx)
            (Ret)
            (compile-defines ds)
            (compile-lambda-defines (lambdas p))

--- a/langs/mountebank/compile.rkt
+++ b/langs/mountebank/compile.rkt
@@ -16,7 +16,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Id]
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Prog -> Asm
 (define (compile p)

--- a/langs/mug/compile-ops.rkt
+++ b/langs/mug/compile-ops.rkt
@@ -55,8 +55,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax val-void))]
+          unpad-stack)]
     ['box
      (seq (Mov (Offset rbx 0) rax)
           (Mov rax rbx)

--- a/langs/mug/compile.rkt
+++ b/langs/mug/compile.rkt
@@ -14,6 +14,7 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Id]
 
@@ -24,13 +25,15 @@
      (prog (externs)
            (Global 'entry)
            (Label 'entry)
-           (Push rbx)    ; save callee-saved register	   
+           (Push rbx)    ; save callee-saved register
+           (Push r15)
            (Mov rbx rdi) ; recv heap pointer
            (init-symbol-table p)
            (compile-defines-values ds)
            (compile-e e (reverse (define-ids ds)) #f)
            (Add rsp (* 8 (length ds))) ;; pop function definitions
-           (Pop rbx)     ; restore callee-save register
+           (Pop r15)     ; restore callee-save register
+           (Pop rbx)
            (Ret)
            (compile-defines ds)
            (compile-lambda-defines (lambdas p))

--- a/langs/mug/compile.rkt
+++ b/langs/mug/compile.rkt
@@ -16,7 +16,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Id]
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Prog -> Asm
 (define (compile p)

--- a/langs/neerdowell/compile-ops.rkt
+++ b/langs/neerdowell/compile-ops.rkt
@@ -53,8 +53,7 @@
           pad-stack
           (Mov rdi rax)
           (Call 'write_byte)
-          unpad-stack
-          (Mov rax val-void))]
+          unpad-stack)]
     ['box
      (seq (Mov (Offset rbx 0) rax)
           (Mov rax rbx)

--- a/langs/neerdowell/compile.rkt
+++ b/langs/neerdowell/compile.rkt
@@ -14,6 +14,7 @@
 (define rbx 'rbx) ; heap
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
+(define r15 'r15) ; stack pad (non-volatile)
 
 ;; type CEnv = [Listof Id]
 
@@ -24,13 +25,15 @@
      (prog (externs)
            (Global 'entry)
            (Label 'entry)
-           (Push rbx)    ; save callee-saved register	   
+           (Push rbx)    ; save callee-saved register
+           (Push r15)
            (Mov rbx rdi) ; recv heap pointer
            (init-symbol-table p)
            (compile-defines-values ds)
            (compile-e e (reverse (define-ids ds)) #f)
            (Add rsp (* 8 (length ds))) ;; pop function definitions
-           (Pop rbx)     ; restore callee-save register
+           (Pop r15)     ; restore callee-save register
+           (Pop rbx)
            (Ret)
            (compile-defines ds)
            (compile-lambda-defines (lambdas p))

--- a/langs/neerdowell/compile.rkt
+++ b/langs/neerdowell/compile.rkt
@@ -16,7 +16,7 @@
 (define rdi 'rdi) ; arg
 (define r15 'r15) ; stack pad (non-volatile)
 
-;; type CEnv = [Listof Id]
+;; type CEnv = (Listof [Maybe Id])
 
 ;; Prog -> Asm
 (define (compile p)

--- a/www/notes/dupe.scrbl
+++ b/www/notes/dupe.scrbl
@@ -1016,14 +1016,16 @@ interpreter and compiler are free to do anything on this input.
 
 Since we know Racket will signal an error when the interpreter tries
 to interpret a meaningless expression, we can write an alternate
-@racket[check-correctness] function that catches any exceptions and
-produces void, effectively ignoring the test:
+@racket[check-correctness] function that first runs the interpreter
+with an exception handler installed.  Should an error occur,
+the test is ignored, otherwise the value produced is compared
+to that of the compiler:
 
 @ex[
 (define (check-correctness e)
   (with-handlers ([exn:fail? void])
-    (check-equal? (interp-compile e)
-                  (interp e))))
+    (let ((v (interp e)))
+      (check-equal? v (interp-compile e)))))
 
 (check-correctness (parse '(add1 7)))
 (check-correctness (parse '(add1 #f)))


### PR DESCRIPTION
- Save and restore the non-volatile register `r15`.
- Avoid unnecessary `(Mov rax (value->bits (void)))` after calling `write_byte`, which returns the void value.
- Touch up the type definition of `CEnv`.