### PR TITLE
fix(notes): Minor typo on note 1

### DIFF
--- a/www/notes/1/ocaml-to-racket.scrbl
+++ b/www/notes/1/ocaml-to-racket.scrbl
@@ -455,7 +455,7 @@ val even_digit : int -> bool = <fun>
 The patterns here, save the last one, are just integer literals.  If
 @tt{n} is the same as any of these integers, the value @tt{true} is
 produced.  The last case uses a "wildcard," which matches anything and
-produces false.
+produces @tt{false}.
 
 Here's an example that matches a tuple, binding each part of the tuple
 to a name and then using those names to construct a different tuple:

--- a/www/notes/1/ocaml-to-racket.scrbl
+++ b/www/notes/1/ocaml-to-racket.scrbl
@@ -455,7 +455,7 @@ val even_digit : int -> bool = <fun>
 The patterns here, save the last one, are just integer literals.  If
 @tt{n} is the same as any of these integers, the value @tt{true} is
 produced.  The last case uses a "wildcard," which matches anything and
-produces true.
+produces false.
 
 Here's an example that matches a tuple, binding each part of the tuple
 to a name and then using those names to construct a different tuple:


### PR DESCRIPTION
Fix a very minor typo


> ```racket
> # let even_digit n =
>     match n with
>     | 0 -> true
>     | 2 -> true
>     | 4 -> true
>     | 6 -> true
>     | 8 -> true
>     | _ -> false;;
> val even_digit : int -> bool = <fun>
> ```
> The patterns here, save the last one, are just integer literals. If n is the same as any of these integers, the value true is produced. The last case uses a "wildcard," which matches anything and produces **~~true~~ false**.