### PR TITLE
Change strange metaphor from Rome to Eiffel Tower

### DIFF
--- a/www/notes/1/what-is-a-compiler.scrbl
+++ b/www/notes/1/what-is-a-compiler.scrbl
@@ -144,10 +144,9 @@ See @secref{Syllabus}.
 
 Write @emph{a compiler} for @tt{MiniRacket -> x86}
 
-But Rome wasn’t built in a day … and neither is any serious software.
+But the Eiffel Tower wasn’t built in a day … and neither is any serious software.
 
 @image{img/Eiffel.jpg}
-Rome wasn’t built in a day
 
 So we will write @emph{many} compilers:
 


### PR DESCRIPTION
In the "Introduction to Compilers" section there is a line: 

> But Rome wasn’t built in a day … and neither is any serious software.

However, the photo attached is a cool photo of the Eiffel Tower under construction.

I changed the reference to "Rome" to the Eiffel Tower to better make the point and remove this inconsistency.