### PR TITLE
Close 164 and 165

### DIFF
--- a/langs/a86/ast.rkt
+++ b/langs/a86/ast.rkt
@@ -37,7 +37,7 @@
       (error n "expects register or offset; given ~v" a2))
     (values a a1 a2)))
 
-(define check:arith  
+(define check:arith
   (λ (a a1 a2 n)
     (unless (register? a1)
       (error n "expects register; given ~v" a1))
@@ -88,7 +88,7 @@
     (unless (or (and (exact-integer? a2) (<= 0 a2 63))
                 (eq? 'cl a2))
       (error n "expects exact integer in [0,63]; given ~v" a2))
-    (values a a1 a2)))      
+    (values a a1 a2)))
 
 (define check:offset
   (λ (a r i n)
@@ -150,7 +150,7 @@
   (syntax-case stx ()
     [(instruct Name (x ...) guard)
      (with-syntax ([Name? (datum->syntax stx (string->symbol (string-append (symbol->string (syntax->datum #'Name)) "?")))])
-     #'(begin (provide Name Name?)              
+     #'(begin (provide Name Name?)
               (define-match-expander Name
                 (lambda (stx)
                   (syntax-case stx ()
@@ -170,13 +170,13 @@
                                               (struct->vector i2))))
                  (define hash-proc  (λ (i hash) (hash (struct->vector i))))
                  (define hash2-proc (λ (i hash) (hash (struct->vector i))))]
-                
+
                 #:property prop:custom-print-quotable 'never
                 #:methods gen:custom-write
                 [(define write-proc
 		   (instr-print 'Name)
                    #;(make-constructor-style-printer
-                    (lambda (obj) 'Name)        
+                    (lambda (obj) 'Name)
                     (lambda (obj)
                       (rest (rest (vector->list (struct->vector obj)))))))])
               (define Name? %Name?)))]))
@@ -212,6 +212,8 @@
 (instruct Sub    (dst src) check:arith)
 (instruct Cmp    (a1 a2)   check:src-dest)
 (instruct Jmp    (x)       check:target)
+(instruct Jz     (x)       check:target)
+(instruct Jnz    (x)       check:target)
 (instruct Je     (x)       check:target)
 (instruct Jne    (x)       check:target)
 (instruct Jl     (x)       check:target)
@@ -222,6 +224,8 @@
 (instruct Jno    (x)       check:target)
 (instruct Jc     (x)       check:target)
 (instruct Jnc    (x)       check:target)
+(instruct Cmovz  (dst src) check:cmov)
+(instruct Cmovnz (dst src) check:cmov)
 (instruct Cmove  (dst src) check:cmov)
 (instruct Cmovne (dst src) check:cmov)
 (instruct Cmovl  (dst src) check:cmov)
@@ -238,9 +242,9 @@
 (instruct Sal    (dst i)   check:shift)
 (instruct Sar    (dst i)   check:shift)
 (instruct Push   (a1)      check:push)
+(instruct Pop    (a1)      check:register)
 (instruct Pushf  ()        check:none)
 (instruct Popf   ()        check:none)
-(instruct Pop    (a1)      check:register)
 (instruct Lea    (dst x)   check:lea)
 (instruct Not    (x)       check:register)
 (instruct Div    (den)     check:register)
@@ -340,7 +344,7 @@
     [(cons (Label s) asm)
      (cons s (label-decls asm))]
     [(cons (Extern s) asm)
-     (cons s (label-decls asm))]    
+     (cons s (label-decls asm))]
     [(cons _ asm)
      (label-decls asm)]))
 
@@ -370,7 +374,7 @@
     [(cons (Call (? label? s)) asm)
      (cons s (label-uses asm))]
     [(cons (Lea _ (? label? s)) asm)
-     (cons s (label-uses asm))]    
+     (cons s (label-uses asm))]
     [(cons _ asm)
      (label-uses asm)]))
 

--- a/langs/a86/ast.rkt
+++ b/langs/a86/ast.rkt
@@ -241,6 +241,8 @@
 (instruct Xor    (dst src) check:src-dest)
 (instruct Sal    (dst i)   check:shift)
 (instruct Sar    (dst i)   check:shift)
+(instruct Shl    (dst i)   check:shift)
+(instruct Shr    (dst i)   check:shift)
 (instruct Push   (a1)      check:push)
 (instruct Pop    (a1)      check:register)
 (instruct Pushf  ()        check:none)

--- a/langs/a86/printer.rkt
+++ b/langs/a86/printer.rkt
@@ -120,6 +120,14 @@
        (string-append tab "sar "
                       (arg->string a1) ", "
                       (arg->string a2))]
+      [(Shl a1 a2)
+       (string-append tab "shl "
+                      (arg->string a1) ", "
+                      (arg->string a2))]
+      [(Shr a1 a2)
+       (string-append tab "shr "
+                      (arg->string a1) ", "
+                      (arg->string a2))]
       [(And a1 a2)
        (string-append tab "and "
                       (arg->string a1) ", "

--- a/langs/a86/printer.rkt
+++ b/langs/a86/printer.rkt
@@ -73,7 +73,7 @@
       [(Plus e1 e2)
        (string-append "(" (exp->string e1) " + " (exp->string e2) ")")]
       [_ (label-symbol->string e)]))
-  
+
   (define tab (make-string 8 #\space))
 
   ;; Instruction -> String
@@ -84,8 +84,8 @@
               (format "~a~a; ~.s" s (make-string (- 40 (string-length s)) #\space) (instruction-annotation i))
               (format "~a ; ~.s" s (instruction-annotation i)))
           s)))
-  
-  
+
+
   ;; Instruction -> String
   (define (simple-instr->string i)
     (match i
@@ -107,7 +107,7 @@
       [(Sub a1 a2)
        (string-append tab "sub "
                       (arg->string a1) ", "
-                      (arg->string a2))]    
+                      (arg->string a2))]
       [(Cmp a1 a2)
        (string-append tab "cmp "
                       (arg->string a1) ", "
@@ -127,13 +127,19 @@
       [(Or a1 a2)
        (string-append tab "or "
                       (arg->string a1) ", "
-                      (arg->string a2))]    
+                      (arg->string a2))]
       [(Xor a1 a2)
        (string-append tab "xor "
                       (arg->string a1) ", "
                       (arg->string a2))]
       [(Jmp l)
        (string-append tab "jmp "
+                      (jump-target->string l))]
+      [(Jz l)
+       (string-append tab "jz "
+                      (jump-target->string l))]
+      [(Jnz l)
+       (string-append tab "jnz "
                       (jump-target->string l))]
       [(Je l)
        (string-append tab "je "
@@ -165,6 +171,14 @@
       [(Jnc l)
        (string-append tab "jnc "
                       (jump-target->string l))]
+      [(Cmovz dst src)
+       (string-append tab "cmovz "
+                      (reg->string dst) ", "
+                      (arg->string src))]
+      [(Cmovnz dst src)
+       (string-append tab "cmovnz "
+                      (reg->string dst) ", "
+                      (arg->string src))]
       [(Cmove dst src)
        (string-append tab "cmove "
                       (reg->string dst) ", "
@@ -211,13 +225,13 @@
       [(Push a)
        (string-append tab "push "
                       (arg->string a))]
+      [(Pop r)
+       (string-append tab "pop "
+                      (reg->string r))]
       [(Pushf)
        (string-append tab "pushf")]
       [(Popf)
        (string-append tab "popf")]
-      [(Pop r)
-       (string-append tab "pop "
-                      (reg->string r))]
       [(Lea d (? offset? x))
        (string-append tab "lea "
                       (arg->string d) ", "

--- a/www/notes/a86.scrbl
+++ b/www/notes/a86.scrbl
@@ -1677,7 +1677,8 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Sal ([dst register?] [i (integer-in 0 63)])]{
  Shift @racket[dst] to the left @racket[i] bits and put result in @racket[dst].
- The leftmost bits are discarded. Updates the conditional flags.
+ The most-significant (leftmost) bits are discarded. Updates the conditional
+ flags.
 
  @#reader scribble/comment-reader
  (ex
@@ -1693,8 +1694,9 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Sar ([dst register?] [i (integer-in 0 63)])]{
  Shift @racket[dst] to the right @racket[i] bits and put result in @racket[dst].
- The rightmost bits are discarded.  The added leftmost bits are filled with the
- sign bit of the original. Updates the conditional flags.
+ For each shift count, the least-significant (rightmost) bit is shifted into
+ the carry flag. The new most-significant (leftmost) bits are filled with the
+ sign bit of the original @racket[dst] value. Updates the conditional flags.
 
  @#reader scribble/comment-reader
  (ex
@@ -1713,6 +1715,52 @@ Each register plays the same role as in x86, so for example
    (Mov 'rax #b100001101) ; #b100001101 = 269
    (Sar 'rax 6)
    (Ret)))        ; #b100 = 4
+
+ (asm-interp
+  (prog
+   (Global 'entry)
+   (Label 'entry)
+   (Mov 'rax #b1000000000000000000000000000000000000000000000000000000000000000) ; 1 in MSB
+   (Sar 'rax 6)
+   (Ret))) ; #b1111111000000000000000000000000000000000000000000000000000000000
+ )
+}
+
+@defstruct*[Shl ([dst register?] [i (integer-in 0 63)])]{
+ Alias for @racket[Sal].
+}
+
+@defstruct*[Shr ([dst register?] [i (integer-in 0 63)])]{
+ Shift @racket[dst] to the right @racket[i] bits and put result in @racket[dst].
+ For each shift count, the least-significant (rightmost) bit is shifted into
+ the carry flag, and the most-significant bit is cleared. Updates the
+ conditional flags.
+
+ @#reader scribble/comment-reader
+ (ex
+ (asm-interp
+  (prog
+   (Global 'entry)
+   (Label 'entry)
+   (Mov 'rax #b100000000) ; #b100000000 = 256
+   (Shr 'rax 6)
+   (Ret)))        ; #b100 = 4
+
+ (asm-interp
+  (prog
+   (Global 'entry)
+   (Label 'entry)
+   (Mov 'rax #b100001101) ; #b100001101 = 269
+   (Shr 'rax 6)
+   (Ret)))        ; #b100 = 4
+
+ (asm-interp
+  (prog
+   (Global 'entry)
+   (Label 'entry)
+   (Mov 'rax #b1000000000000000000000000000000000000000000000000000000000000000) ; 1 in MSB
+   (Shr 'rax 6)
+   (Ret))) ; #b0000001000000000000000000000000000000000000000000000000000000000
  )
 }
 

--- a/www/notes/a86.scrbl
+++ b/www/notes/a86.scrbl
@@ -1314,6 +1314,12 @@ Each register plays the same role as in x86, so for example
 @defstruct*[Cmovz ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the zero flag is set.
 
+ Note that the semantics for conditional moves is not what many people expect.
+ The @dst[src] is @emph{always} read, regardless of the condition's evaluation.
+ This means that if your source is illegal (such as an offset beyond the bounds
+ of memory allocated to the current process), a segmentation fault will arise
+ even if the condition ``should have'' prevented the error.
+
  @ex[
  (asm-interp
   (prog
@@ -1339,7 +1345,7 @@ Each register plays the same role as in x86, so for example
 
 
 @defstruct*[Cmove ([dst register?] [src (or/c register? offset?)])]{
- An alias for @racket[Cmovz].
+ An alias for @racket[Cmovz]. See notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1366,6 +1372,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovnz ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the zero flag is @emph{not} set.
+ See notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1391,7 +1398,7 @@ Each register plays the same role as in x86, so for example
 }
 
 @defstruct*[Cmovne ([dst register?] [src (or/c register? offset?)])]{
- An alias for @racket[Cmovnz].
+ An alias for @racket[Cmovnz]. See notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1418,6 +1425,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovl ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the conditional flags are set to ``less than'' (see @secref{a86-flags}).
+ See also the notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1444,6 +1452,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovle ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the conditional flags are set to ``less than or equal'' (see @secref{a86-flags}).
+ See also the notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1470,6 +1479,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovg ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the conditional flags are set to ``greather than'' (see @secref{a86-flags}).
+ See also the notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1496,6 +1506,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovge ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the conditional flags are set to ``greater than or equal'' (see @secref{a86-flags}).
+ See also the notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1522,6 +1533,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovo ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the overflow flag is set.
+ See notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1548,6 +1560,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovno ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the overflow flag is @emph{not} set.
+ See notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1574,6 +1587,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovc ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the carry flag is set.
+ See notes on @racket[Cmovz].
 
  @ex[
  (asm-interp
@@ -1600,6 +1614,7 @@ Each register plays the same role as in x86, so for example
 
 @defstruct*[Cmovnc ([dst register?] [src (or/c register? offset?)])]{
  Move from @racket[src] to @racket[dst] if the carry flag is @emph{not} set.
+ See notes on @racket[Cmovz].
 
  @ex[
  (asm-interp


### PR DESCRIPTION
Adds instructions:

- `Jz`
- `Jnz`
- `Cmovz`
- `Cmovnz`
- `Shl`
- `Shr`

Updates documentation accordingly.

Documentation also extended to explain the FLAGS register more explicitly, and instructions that modify the flags are explicitly annotated.