### PR TITLE
fixes check-compiler string message error

### DIFF
--- a/www/notes/con.scrbl
+++ b/www/notes/con.scrbl
@@ -308,7 +308,7 @@ Again, we formulate correctness as a property that can be tested:
 (define (check-compiler e)
   (check-equal? (asm-interp (compile e))
                 (interp e)
-                e))]
+                (~a e)))]
 
 Generating random Con programs is essentially the same as Blackmail
 programs, and are provided in a @link["con/random.rkt"]{random.rkt}


### PR DESCRIPTION
`check-equal?` is showing an error because the third argument is not a string. This fix converts the third argument of `check-equal?` from an expression to a string. 